### PR TITLE
feat: 글쓰기 페이지, 모달 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@stackoverflow/stacks-editor": "^0.8.8",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -16,6 +17,7 @@
     "react-hook-form": "^7.45.4",
     "react-router-dom": "^6.14.2",
     "react-scripts": "5.0.1",
+    "react-uuid": "^2.0.0",
     "recoil": "^0.7.7",
     "styled-components": "^6.0.7",
     "typescript": "^4.9.5",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import type { RouteObject } from "react-router-dom";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { RecoilRoot } from "recoil";
+import Error from "./pages/Error";
 import Main from "./pages/Main";
 import Questions from "./pages/Questions";
 import RootLayout from "./pages/Root";
@@ -26,6 +27,7 @@ function App() {
       path: "/write",
       element: <Write />,
     },
+    { path: "*", element: <Error /> },
   ];
 
   const router = createBrowserRouter(routes);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,8 +3,8 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { RecoilRoot } from "recoil";
 import Main from "./pages/Main";
 import Questions from "./pages/Questions";
-
 import RootLayout from "./pages/Root";
+import Write from "./pages/Write";
 
 function App() {
   const routes: RouteObject[] = [
@@ -21,6 +21,10 @@ function App() {
           element: <Questions />,
         },
       ],
+    },
+    {
+      path: "/write",
+      element: <Write />,
     },
   ];
 

--- a/client/src/atoms/atoms.ts
+++ b/client/src/atoms/atoms.ts
@@ -5,3 +5,8 @@ export const questionsState = atom<Question[]>({
   key: "questionsState",
   default: [],
 });
+
+export const modalState = atom<boolean>({
+  key: "modalState",
+  default: false,
+});

--- a/client/src/atoms/atoms.ts
+++ b/client/src/atoms/atoms.ts
@@ -1,16 +1,7 @@
-import axios from "axios";
-import { atom, selector } from "recoil";
+import { atom } from "recoil";
 import { Question } from "../types/types";
 
 export const questionsState = atom<Question[]>({
   key: "questionsState",
   default: [],
-});
-
-export const readData = selector<Array<Question>>({
-  key: "readData",
-  get: async () => {
-    const response = await axios.get("http://localhost:3001/question");
-    return response.data;
-  },
 });

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -1,0 +1,114 @@
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import styled from "styled-components";
+import { modalState } from "../../atoms/atoms";
+
+interface ModalProp {
+  children: JSX.Element;
+}
+
+const StyledModal = styled.div`
+  z-index: 999;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgb(26, 5, 6, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  section {
+    position: relative;
+    max-width: 37.5rem;
+    background: #fff;
+    padding: 1.5rem;
+    box-shadow:
+      0 1px 4px hsla(0, 0%, 0%, 0.09),
+      0 3px 8px hsla(0, 0%, 0%, 0.09),
+      0 4px 13px hsla(0, 0%, 0%, 0.13);
+    border-radius: 8px;
+
+    .close-button {
+      position: absolute;
+      padding: 1rem;
+      top: 0;
+      right: 0;
+      cursor: pointer;
+    }
+
+    h1 {
+      font-size: 1.6875rem;
+      color: #c22e32;
+      margin: 0 0 1rem;
+    }
+
+    p {
+      font-size: 0.8125rem;
+      margin: 0 0 1.5rem;
+    }
+
+    button {
+      padding: 0.8rem;
+      border-radius: 6px;
+      border: none;
+    }
+
+    .button-gap {
+      display: flex;
+      flex-flow: row;
+      gap: 0.5rem;
+    }
+
+    .discard-action {
+      background: #c22e32;
+      color: #fff;
+
+      &:hover {
+        background: #ab262a;
+      }
+    }
+
+    .cancel-action {
+      background: transparent;
+
+      &:hover {
+        background: #f9fafa;
+      }
+    }
+  }
+`;
+
+const Modal = ({ children }: ModalProp): JSX.Element => {
+  const setModal = useSetRecoilState(modalState);
+  const modalIsOpen = useRecoilValue(modalState);
+
+  const closeModal = (event: React.MouseEvent<HTMLElement>) => {
+    if (event.target === event.currentTarget) setModal(false);
+  };
+
+  const toggleModal = () => {
+    setModal(!modalIsOpen);
+  };
+
+  return (
+    <StyledModal onClick={closeModal}>
+      <section className="modal">
+        <div className="close-button" onClick={toggleModal}>
+          <svg
+            aria-hidden="true"
+            className="svg-icon iconClearSm"
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+          >
+            <path d="M12 3.41 10.59 2 7 5.59 3.41 2 2 3.41 5.59 7 2 10.59 3.41 12 7 8.41 10.59 12 12 10.59 8.41 7 12 3.41Z"></path>
+          </svg>
+        </div>
+        {children}
+      </section>
+    </StyledModal>
+  );
+};
+
+export default Modal;

--- a/client/src/components/main/QuestionList.tsx
+++ b/client/src/components/main/QuestionList.tsx
@@ -5,6 +5,7 @@ import { questionsState } from "../../atoms/atoms";
 import { COMMON_CSS } from "../../constants/common_css";
 import { useFetch } from "../../hooks/useFetch";
 import { Question } from "../../types/types";
+import { getFormattedDate } from "../../util/date";
 
 const StyledQuestionList = styled.section`
   color: ${COMMON_CSS["font-color-black"]};
@@ -66,6 +67,15 @@ const QuestionList = () => {
     fetchData();
   }, []);
 
+  const printState = (createdAt: string, modifiedAt: string): string => {
+    return createdAt === modifiedAt ? "asked" : "modified";
+  };
+
+  const printDate = (createdAt: string, modifiedAt: string): string => {
+    const date = new Date(createdAt === modifiedAt ? createdAt : modifiedAt);
+    return getFormattedDate(date);
+  };
+
   return (
     <StyledQuestionList>
       {isLoading && <div>Loading...</div>}
@@ -86,8 +96,12 @@ const QuestionList = () => {
               <p className="summary">{question.content}</p>
               <div className="user">
                 <span className="id">{question.member_id}</span>
-                <span className="activity">{question.modifiedAt ? "modefied" : "asked"}</span>
-                <span className="timestamp">{question.createdAt}</span>
+                <span className="activity">
+                  {printState(question.createdAt, question.modifiedAt)}
+                </span>
+                <span className="timestamp">
+                  {printDate(question.createdAt, question.modifiedAt)}
+                </span>
               </div>
             </li>
           ))}

--- a/client/src/components/main/QuestionList.tsx
+++ b/client/src/components/main/QuestionList.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { questionsState, readData } from "../../atoms/atoms";
+import { questionsState } from "../../atoms/atoms";
 import { COMMON_CSS } from "../../constants/common_css";
 import { useFetch } from "../../hooks/useFetch";
 import { Question } from "../../types/types";
@@ -56,7 +57,14 @@ const StyledQuestionList = styled.section`
 `;
 
 const QuestionList = () => {
-  const { isLoading, isError, data } = useFetch<Question[]>(questionsState, readData);
+  const { fetchData, isLoading, isError, data } = useFetch<Question[]>(
+    questionsState,
+    "http://localhost:3001/question",
+  );
+
+  useEffect(() => {
+    fetchData();
+  }, []);
 
   return (
     <StyledQuestionList>
@@ -65,13 +73,13 @@ const QuestionList = () => {
       {!isLoading && (
         <ul>
           {data.map((question) => (
-            <li key={question.question_id}>
+            <li key={question.id}>
               {/* <div className="count">
                 <span className="answers-count">0 answers</span>
                 <span className="views">0 views</span>
               </div> */}
               <h3>
-                <Link to={`/questions/${question.question_id}`} className="question-title">
+                <Link to={`/questions/${question.id}`} className="question-title">
                   {question.title}
                 </Link>
               </h3>

--- a/client/src/components/main/QuestionListTitle.tsx
+++ b/client/src/components/main/QuestionListTitle.tsx
@@ -2,35 +2,35 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { COMMON_CSS } from "../../constants/common_css";
 
+const StyledListTitle = styled.section`
+  padding: 1rem 1rem 1.5rem;
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  justify-content: space-between;
+
+  h1 {
+    font-size: 1.6875rem;
+  }
+
+  .ask-button {
+    font-size: 0.8125rem;
+    background: ${COMMON_CSS["button-color"]};
+    color: #fff;
+    padding: 0.8rem;
+    border-radius: 6px;
+
+    &:hover {
+      background: ${COMMON_CSS["button-hover-color"]};
+    }
+  }
+`;
+
 const QuestionListTitle = () => {
-  const StyledListTitle = styled.section`
-    padding: 1rem 1rem 1.5rem;
-    display: flex;
-    flex-flow: row;
-    align-items: center;
-    justify-content: space-between;
-
-    h1 {
-      font-size: 1.6875rem;
-    }
-
-    .ask-button {
-      font-size: 0.8125rem;
-      background: ${COMMON_CSS["button-color"]};
-      color: #fff;
-      padding: 0.8rem;
-      border-radius: 6px;
-
-      &:hover {
-        background: ${COMMON_CSS["button-hover-color"]};
-      }
-    }
-  `;
-
   return (
     <StyledListTitle>
       <h1> All Questions</h1>
-      <Link to="/" className="ask-button">
+      <Link to="/write" className="ask-button">
         Ask Question
       </Link>
     </StyledListTitle>

--- a/client/src/components/write/WriteForm.tsx
+++ b/client/src/components/write/WriteForm.tsx
@@ -130,6 +130,7 @@ const WriteForm = (): JSX.Element => {
     data = {
       ...data,
       createdAt: new Date().toISOString(),
+      modifiedAt: new Date().toISOString(),
       member_id: 1,
     };
 

--- a/client/src/components/write/WriteForm.tsx
+++ b/client/src/components/write/WriteForm.tsx
@@ -3,7 +3,7 @@
 // import "@stackoverflow/stacks-editor/dist/styles.css";
 // import "@stackoverflow/stacks/dist/css/stacks.css";
 import axios, { AxiosError } from "axios";
-import { useState } from "react";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
@@ -51,6 +51,12 @@ const StyledField = styled.div`
     border-radius: 6px;
     border: none;
     color: #fff;
+
+    &:hover,
+    &:focus {
+      outline: none;
+      background: ${COMMON_CSS["button-hover-color"]};
+    }
   }
 
   #editor-container {
@@ -90,7 +96,9 @@ const StyledDiscardButton = styled.button`
   padding: 0.8rem;
   border-radius: 6px;
 
-  &:hover {
+  &:hover,
+  &:focus {
+    outline: none;
     background: #fdf2f2;
   }
 `;

--- a/client/src/components/write/WriteForm.tsx
+++ b/client/src/components/write/WriteForm.tsx
@@ -40,7 +40,6 @@ const StyledField = styled.div`
   }
 
   textarea {
-    resize: none;
     min-height: 18.75rem;
   }
 
@@ -115,6 +114,14 @@ const WriteForm = (): JSX.Element => {
     setIsActive(true);
   };
 
+  //isActive가 아닐때 tab키로 cursor이동 방지
+  const onKeyDownHandler = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Tab") {
+      console.log(event);
+      event.preventDefault();
+    }
+  };
+
   const onSubmit = async (data: Question) => {
     // const editorData = document.querySelector(".js-editor") as HTMLElement;
     // const formData = { ...data, content: editorData.innerHTML };
@@ -173,7 +180,11 @@ const WriteForm = (): JSX.Element => {
         <label htmlFor="title">Title</label>
         <p>Be specific and imagine you’re asking a question to another person.</p>
         <input id="title" {...register("title")} />
-        <button className="button" onClick={onClickHandler}>
+        <button
+          className="button"
+          onClick={onClickHandler}
+          onKeyDown={isActive ? undefined : onKeyDownHandler}
+        >
           Next
         </button>
       </StyledField>

--- a/client/src/components/write/WriteForm.tsx
+++ b/client/src/components/write/WriteForm.tsx
@@ -1,0 +1,159 @@
+// import "@stackoverflow/stacks";
+// import { StacksEditor } from "@stackoverflow/stacks-editor";
+// import "@stackoverflow/stacks-editor/dist/styles.css";
+// import "@stackoverflow/stacks/dist/css/stacks.css";
+import axios, { AxiosError } from "axios";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { questionsState } from "../../atoms/atoms";
+import { COMMON_CSS } from "../../constants/common_css";
+import { useFetch } from "../../hooks/useFetch";
+import { Question } from "../../types/types";
+
+const StyledField = styled.div`
+  label {
+    font-size: 0.9375rem;
+    font-weight: 600;
+  }
+
+  p {
+    font-size: 0.75rem;
+    margin: 0 0 0.9375rem;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    padding: 0.5rem 0.5625rem;
+    border-radius: 6px;
+    border: 1px solid #babfc4;
+
+    &:focus {
+      outline: none;
+      border: 1px solid #6ebcf7;
+      box-shadow: 0 0 0 4px #dff1ff;
+    }
+  }
+
+  textarea {
+    resize: none;
+    min-height: 18.75rem;
+  }
+
+  .button {
+    background: ${COMMON_CSS["button-color"]};
+    padding: 0.8125rem;
+    margin: 0.625rem 0 0;
+    border-radius: 6px;
+    border: none;
+    color: #fff;
+  }
+
+  #editor-container {
+    button {
+      padding: 0.1875rem;
+    }
+
+    ul,
+    ol {
+      margin-left: 1.25rem;
+    }
+
+    p {
+      font-size: 1rem;
+    }
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    border: 1px solid #a5a5a5;
+    opacity: 0.3;
+
+    button {
+      display: none;
+    }
+
+    textarea {
+      pointer-events: none;
+    }
+  }
+`;
+
+const WriteForm = (): JSX.Element => {
+  const { fetchData } = useFetch(questionsState, "http://localhost:3001/question");
+  const navigate = useNavigate();
+  const [isActive, setIsActive] = useState(false);
+  const { register, handleSubmit } = useForm<Question>();
+
+  const onClickHandler = () => {
+    setIsActive(true);
+  };
+
+  const onSubmit = async (data: Question) => {
+    // const editorData = document.querySelector(".js-editor") as HTMLElement;
+    // const formData = { ...data, content: editorData.innerHTML };
+    // console.log(formData);
+
+    data = {
+      ...data,
+      createdAt: new Date().toISOString(),
+      member_id: 1,
+    };
+
+    try {
+      const response = await axios.post("http://localhost:3001/question", data);
+      if (response) {
+        navigate("/");
+        fetchData();
+      }
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      navigate("/error", {
+        state: { status: axiosError.status, errorMessage: axiosError.message },
+      });
+    }
+  };
+  // const [editorInitialized, setEditorInitialized] = useState(false);
+
+  // useEffect(() => {
+  //   if (!editorInitialized) {
+  //     setEditorInitialized(true);
+  //   } else {
+  //     const editorContainer = document.querySelector("#editor-container") as HTMLElement;
+  //     if (editorContainer) {
+  //       new StacksEditor(editorContainer, "", {
+  //         parserFeatures: {
+  //           tables: false,
+  //         },
+  //       });
+  //     }
+  //   }
+  // }, [editorInitialized]);
+
+  return (
+    <>
+      <StyledField className="box">
+        <label htmlFor="title">Title</label>
+        <p>Be specific and imagine you’re asking a question to another person.</p>
+        <input id="title" {...register("title")} />
+        <button className="button" onClick={onClickHandler}>
+          Next
+        </button>
+      </StyledField>
+
+      <StyledField className={`box ${isActive ? "" : "disabled"}`}>
+        <label htmlFor="content">What are the details of your problem?</label>
+        <p>Introduce the problem and expand on what you put in the title. Minimum 20 characters.</p>
+        <textarea id="content" {...register("content")}></textarea>
+        {/* <div id="editor-container"></div> */}
+        <button className="button" onClick={handleSubmit(onSubmit)}>
+          Submit
+        </button>
+      </StyledField>
+    </>
+  );
+};
+
+export default WriteForm;

--- a/client/src/components/write/WriteForm.tsx
+++ b/client/src/components/write/WriteForm.tsx
@@ -6,11 +6,13 @@ import axios, { AxiosError } from "axios";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
-import { questionsState } from "../../atoms/atoms";
+import { modalState, questionsState } from "../../atoms/atoms";
 import { COMMON_CSS } from "../../constants/common_css";
 import { useFetch } from "../../hooks/useFetch";
 import { Question } from "../../types/types";
+import Modal from "../common/Modal";
 
 const StyledField = styled.div`
   label {
@@ -81,11 +83,25 @@ const StyledField = styled.div`
   }
 `;
 
+const StyledDiscardButton = styled.button`
+  color: #ab262a;
+  background: transparent;
+  border: none;
+  padding: 0.8rem;
+  border-radius: 6px;
+
+  &:hover {
+    background: #fdf2f2;
+  }
+`;
+
 const WriteForm = (): JSX.Element => {
   const { fetchData } = useFetch(questionsState, "http://localhost:3001/question");
   const navigate = useNavigate();
   const [isActive, setIsActive] = useState(false);
-  const { register, handleSubmit } = useForm<Question>();
+  const setModal = useSetRecoilState(modalState);
+  const modalIsOpen = useRecoilValue(modalState);
+  const { register, handleSubmit, reset } = useForm<Question>();
 
   const onClickHandler = () => {
     setIsActive(true);
@@ -115,6 +131,17 @@ const WriteForm = (): JSX.Element => {
       });
     }
   };
+
+  const toggleModal = () => {
+    setModal(!modalIsOpen);
+  };
+
+  const resetValue = () => {
+    reset({ title: "", content: "" });
+    setModal(!modalIsOpen);
+    setIsActive(false);
+  };
+
   // const [editorInitialized, setEditorInitialized] = useState(false);
 
   // useEffect(() => {
@@ -149,9 +176,32 @@ const WriteForm = (): JSX.Element => {
         <textarea id="content" {...register("content")}></textarea>
         {/* <div id="editor-container"></div> */}
         <button className="button" onClick={handleSubmit(onSubmit)}>
-          Submit
+          Post your question
         </button>
       </StyledField>
+
+      {modalIsOpen && (
+        <Modal>
+          <>
+            <h1>Discard question</h1>
+            <p>Are you sure you want to discard this question? This cannot be undone.</p>
+            <div className="button-gap">
+              <button className="discard-action" onClick={resetValue}>
+                Discard question
+              </button>
+              <button className="cancel-action" onClick={toggleModal}>
+                Cancel
+              </button>
+            </div>
+          </>
+        </Modal>
+      )}
+
+      {isActive && (
+        <StyledDiscardButton onClick={toggleModal} className="discard-button">
+          Discard draft
+        </StyledDiscardButton>
+      )}
     </>
   );
 };

--- a/client/src/components/write/WritePageTitle.tsx
+++ b/client/src/components/write/WritePageTitle.tsx
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+import { COMMON_CSS } from "../../constants/common_css";
+
+const StyledTitle = styled.div`
+  width: 100%;
+
+  .title {
+    height: 8.125rem;
+    display: flex;
+    align-items: center;
+
+    h1 {
+      font-weight: 600;
+      margin: 1.5rem 0;
+      font-size: 1.6875rem;
+    }
+  }
+
+  .box.notice {
+    border: 1px solid #a6ceed;
+    background: #ebf4fb;
+    color: ${COMMON_CSS["font-color-black"]};
+
+    h2 {
+      font-size: 1.3125rem;
+      margin: 0 0 0.5rem;
+    }
+
+    p {
+      font-size: 15px;
+
+      &:last-of-type {
+        margin: 0 0 0.9375rem;
+      }
+    }
+
+    h5 {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      margin: 0 0 0.5rem;
+    }
+
+    ul {
+      list-style: disc;
+      margin: 0 0 0 1.875rem;
+      font-size: 0.8125rem;
+    }
+  }
+`;
+
+const WritePageTitle = () => {
+  return (
+    <StyledTitle>
+      <div className="title">
+        <h1>Ask a public question</h1>
+      </div>
+      <div className="notice box">
+        <h2>Writing a good question</h2>
+        <p>
+          You’re ready to ask a programming-related question and this form will help guide you
+          through the process.
+        </p>
+        <p>
+          Looking to ask a non-programming question? See the topics here to find a relevant site.
+        </p>
+        <h5>Steps</h5>
+        <ul>
+          <li>Summarize your problem in a one-line title.</li>
+          <li>Describe your problem in more detail.</li>
+          <li>Describe what you tried and what you expected to happen.</li>
+          <li>Add “tags” which help surface your question to members of the community.</li>
+          <li>Review your question and post it to the site.</li>
+        </ul>
+      </div>
+    </StyledTitle>
+  );
+};
+
+export default WritePageTitle;

--- a/client/src/hooks/useFetch.tsx
+++ b/client/src/hooks/useFetch.tsx
@@ -1,41 +1,38 @@
+import axios from "axios";
 import { useEffect, useState } from "react";
-import { RecoilState, RecoilValue, useRecoilState, useRecoilValueLoadable } from "recoil";
+import { RecoilState, useRecoilState } from "recoil";
 
 export interface FetchReturn<T> {
+  fetchData: () => void;
   isLoading: boolean;
   isError: boolean;
   data: T;
 }
 
-export const useFetch = <T extends object>(
-  atom: RecoilState<T>,
-  selector: RecoilValue<T>,
-): FetchReturn<T> => {
+export const useFetch = <T extends object>(atom: RecoilState<T>, url: string): FetchReturn<T> => {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [data, setData] = useRecoilState(atom);
-  const readDataLoadable = useRecoilValueLoadable(selector);
+  const fetchData = async () => {
+    setIsLoading(true);
+    setIsError(false);
 
-  const fetchData = () => {
-    switch (readDataLoadable.state) {
-      case "loading":
-        setIsLoading(true);
-        break;
-      case "hasValue":
-        setIsLoading(false);
-        setData(readDataLoadable.contents);
-        break;
-      case "hasError":
-        setIsError(true);
-        setIsLoading(false);
+    try {
+      const response = await axios.get(url);
+      setData(response.data);
+      setIsLoading(false);
+    } catch (error) {
+      setIsError(true);
+      setIsLoading(false);
     }
   };
 
   useEffect(() => {
     fetchData();
-  }, [fetchData]);
+  }, []);
 
   return {
+    fetchData,
     isLoading,
     isError,
     data,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,5 @@
-body {
+body,
+textarea {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,6 +35,7 @@ textarea,
 ul {
   margin: 0;
   padding: 0;
+  letter-spacing: -0.1px;
 }
 
 h1,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -59,6 +59,10 @@ select {
   padding: 0;
 }
 
+button:hover {
+  cursor: pointer;
+}
+
 html {
   box-sizing: border-box;
 }

--- a/client/src/pages/Error.tsx
+++ b/client/src/pages/Error.tsx
@@ -1,0 +1,17 @@
+import { useLocation } from "react-router-dom";
+
+const Error = () => {
+  const location = useLocation();
+  const status = location.state?.status;
+  const errorMessage = location.state?.errorMessage;
+
+  return (
+    <div>
+      {status && <h1>{status}</h1>}
+      {errorMessage && <p>Error: {errorMessage}</p>}
+      {!location.state && <p>Error: Not Found</p>}
+    </div>
+  );
+};
+
+export default Error;

--- a/client/src/pages/Write.tsx
+++ b/client/src/pages/Write.tsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import Footer from "../components/common/Footer";
+import Header from "../components/common/Header";
+import WriteForm from "../components/write/WriteForm";
+import WritePageTitle from "../components/write/WritePageTitle";
+
+const StyledLayout = styled.main`
+  max-width: 79rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 1.5rem;
+
+  display: flex;
+  align-items: flex-start;
+  flex-flow: column;
+  gap: 1rem;
+
+  .box {
+    width: 100%;
+    padding: 1.5rem;
+    border: 1px solid #d6d9dc;
+    border-radius: 6px;
+  }
+`;
+
+const Write = () => {
+  return (
+    <>
+      <Header />
+      <StyledLayout>
+        <WritePageTitle />
+        <WriteForm />
+      </StyledLayout>
+      <Footer />
+    </>
+  );
+};
+
+export default Write;

--- a/client/src/pages/Write.tsx
+++ b/client/src/pages/Write.tsx
@@ -7,7 +7,7 @@ import WritePageTitle from "../components/write/WritePageTitle";
 const StyledLayout = styled.main`
   max-width: 79rem;
   margin: 0 auto;
-  padding: 0 1.5rem 1.5rem;
+  padding: 0 1.5rem 3.75rem;
 
   display: flex;
   align-items: flex-start;

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -1,5 +1,5 @@
 export interface Question {
-  question_id: number;
+  id: string;
   title: string;
   createdAt: string;
   modifiedAt?: string;

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -2,7 +2,7 @@ export interface Question {
   id: string;
   title: string;
   createdAt: string;
-  modifiedAt?: string;
+  modifiedAt: string;
   member_id: number;
   content: string;
 }
@@ -11,7 +11,7 @@ export interface Answer {
   answer_id: number;
   title: string;
   createdAt: string;
-  modifiedAt?: string;
+  modifiedAt: string;
   member_id: number;
   question_id: string;
 }

--- a/client/src/util/date.ts
+++ b/client/src/util/date.ts
@@ -1,0 +1,9 @@
+export const getFormattedDate = (date: Date): string => {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  const hour = date.getHours().toString().padStart(2, "0");
+  const minute = date.getMinutes().toString().padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+};


### PR DESCRIPTION
* 글쓰기 페이지
제목을 입력해야 내용을 작성할 수 있게 구현했습니다.
작성중인 내용을 초기화할 수 있습니다.
글을 작성하면 질문리스트에 작성된 글이 반영됩니다.

* 에러 페이지
네트워크 에러 등의 사유로 글쓰기에 실패할경우 에러 페이지로 이동하게 됩니다.
개발자가 설정하지 않은 경로로 사용자가 이동 시도할 시 에러페이지를 만나게 됩니다.
에러페이지는 따로 스타일링을 하지는 않은 상태입니다.

* 모달
공통 컴포넌트로 제작하여 다른 페이지에서도 범용으로 사용할 수 있습니다.
모달 상태를 전역으로 관리하는 recoil atom을 추가했습니다.

* 기타
selector 사용이 미숙한것 같아서 셀렉터를 사용하지 않고 atom을 변경하도록 구현했습니다.